### PR TITLE
Fix an issue where `__webpack_nonce__` is minified in production builds

### DIFF
--- a/.size-limit.js
+++ b/.size-limit.js
@@ -1,6 +1,6 @@
 module.exports = [
   {
     path: 'dist/es2015/index.js',
-    limit: '0.05 KB',
+    limit: '0.08 KB',
   },
 ];

--- a/.size.json
+++ b/.size.json
@@ -2,6 +2,6 @@
   {
     "name": "dist/es2015/index.js",
     "passed": true,
-    "size": 51
+    "size": 80
   }
 ]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,1 +1,5 @@
+## 1.0.1 (2022-03-17)
+
+- Fix an issue where `__webpack_nonce__` is minified in production builds.
+
 # 1.0.0 (2020-04-16)

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,7 +4,11 @@ export const setNonce = (nonce: string) => {
   currentNonce = nonce;
 };
 
-declare var __webpack_nonce__: string;
+declare global {
+  interface Window {
+    __webpack_nonce__: string;
+  }
+}
 
 export const getNonce = () => {
   // local value is most important
@@ -13,8 +17,8 @@ export const getNonce = () => {
   }
 
   // build in webpack support
-  if (typeof __webpack_nonce__ !== 'undefined') {
-    return __webpack_nonce__;
+  if (typeof window.__webpack_nonce__ !== 'undefined') {
+    return window.__webpack_nonce__;
   }
 
   // parcel does not support nonce by itself


### PR DESCRIPTION
I'm still trying to understand what is happening, it's a bit strange. To give a bit context. We are using `react-focus-on` in our create-react-app 5 app. Our setup is using a quite strict CSP with nonces, which works fine for styled components and other libraries. We are initializing `window.__webpack_nonce__` before our code is run in a separate script tag (I think this might be relevant). My problem occurs in production builds.

However, I'm getting errors for `react-focus-on` that the style tag cannot be inserted because of the missing nonce. I verified and `window.__webpack_nonce__` is actually set correctly and matches our CSP. So I started to dig into it by debugging the code and landed in this package. While I know that this package is evaluating `__webpack_nonce__`, the generated code isn't 😱 

For https://github.com/theKashey/react-style-singleton/blob/master/src/singleton.ts#L5-L17 the following code is generated in our production build:

```javascript
function Pg() {
    if (!document)
        return null;
    var e = document.createElement("style");
    e.type = "text/css";
    var t = Cg || n.nc;
    return t && e.setAttribute("nonce", t),
    e
}
```

As you can see, the `getNonce` call (https://github.com/theKashey/get-nonce/blob/master/src/index.ts#L9-L25) is completely inline and reduced to `var t = Cg || n.nc`. From the code I guess that `n.nc` should probably be `__webpack_nonce__`, but that variable is not initialized. Other parts of the code are accessing `window.__webpack_nonce__` (e.g. styled components).

My first idea is to replace `__webpack_nonce__` with `window.__webpack_nonce__`. When I then rebuild, I get:

```javascript
var t = Cg || ("undefined" !== typeof window.__webpack_nonce__ ? window.__webpack_nonce__ : void 0);
```

Therefore I suggest to replace it.